### PR TITLE
Completed task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ yarn-error.log
 /phpunit.xml
 .phpunit.result.cache
 ###< phpunit/phpunit ###
+
+.history

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,3 +1,3 @@
 body {
-    background-color: lightgray;
+    background-color: #f2f2f2;
 }

--- a/assets/js/components/ExchangeRates.js
+++ b/assets/js/components/ExchangeRates.js
@@ -1,0 +1,141 @@
+// ./assets/js/components/Users.js
+
+import React, { Component } from "react";
+import axios from "axios";
+import { getBaseUrl } from "../config/config";
+import { getFormattedDate } from '../utils/dateUtils';
+
+class ExchangeRates extends Component {
+  constructor() {
+    super();
+    this.state = { exRatesData: {}, loading: true, selectedDate: '', error: '' };
+  }
+
+  componentDidMount() {
+    const params = new URLSearchParams(window.location.search);
+    const dateFromUrl = params.get('date') || '';
+    let selectedDate = dateFromUrl;
+    if ((new Date(dateFromUrl)).toString() === "Invalid Date") {
+        selectedDate = getFormattedDate();
+    }
+    this.updateExchangeRates(selectedDate);
+    this.setState({ selectedDate });
+  }
+
+  updateExchangeRates(date = "") {
+    const baseUrl = getBaseUrl();
+    this.setState({ loading: true, error: ''});
+    axios
+      .get(baseUrl + `/api/exchange-rates`, { params: { date } })
+      .then((response) => {
+        const url = new URL(window.location);
+        url.searchParams.set('date', date);
+        window.history.pushState({}, '', url);
+
+        this.setState({ exRatesData: response.data, loading: false });
+      })
+      .catch((error) => {
+        //debugger;
+        //console.error(error);
+        this.setState({ exRatesData: null, loading: false, error: error.response.data.error });
+      });
+  }
+
+  handleDateChange = (event) => {
+    this.setState({ selectedDate: event.target.value });
+  };
+
+  handleSubmit = () => {
+    this.updateExchangeRates(this.state.selectedDate);
+  };
+
+  render() {
+    const loading = this.state.loading;
+    return (
+      <div>
+        <section className="row-section">
+          <div className="container">
+            <div className="row mt-5">
+              <div className="col-md-8 offset-md-2">
+                <h2 className="text-center mb-4">Exchange rates</h2>
+                <div className={"text-center"}>
+                  <div className="text-center small text-muted mb-1">
+                    Compare today's rate to
+                  </div>
+                  <div className="d-flex justify-content-center mb-2">
+                    <input
+                      type="date"
+                      min="2023-01-01"
+                      value={this.state.selectedDate}
+                      onChange={this.handleDateChange}
+                      className="form-control w-25 mr-3"
+                    />
+                    <button
+                      onClick={this.handleSubmit}
+                      className="btn btn-primary"
+                    >
+                      Get Rates
+                    </button>
+                  </div>
+                  <div className="text-center small text-muted mb-4">
+                    Archive data available for exchange rates – from January 1,
+                    2023.
+                  </div>
+                  {this.state.error ? (
+                    <p className="text-danger">{this.state.error}</p>
+                  ) : (loading || !this.state.exRatesData) ? (
+                    <span className="fa fa-spin fa-spinner fa-4x"></span>
+                  ) : (
+                    <table className="table table-striped mb-8">
+                      <thead className="thead-light">
+                        <tr>
+                          <th>Date</th>
+                          <th>Currency</th>
+                          <th>Mid Rate</th>
+                          <th>Buy Rate</th>
+                          <th>Sell Rate</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {this.state.exRatesData && this.state.exRatesData.rates &&
+                          this.state.exRatesData.rates.map((rate, index) => (
+                            <React.Fragment key={index}>
+                              <tr>
+                                <td>{this.state.exRatesData.latestDate}</td>
+                                <td>{rate.code}</td>
+                                <td>{rate.mid} zł</td>
+                                <td>{rate.buy ? rate.buy + " zł" : "N/A"}</td>
+                                <td>{rate.sell ? rate.sell + " zł" : "N/A"}</td>
+                              </tr>
+                              {rate.selected && (
+                                <tr>
+                                  <td>{this.state.exRatesData.selectedDate}</td>
+                                  <td>{rate.selected.code}</td>
+                                  <td>{rate.selected.mid} zł</td>
+                                  <td>
+                                    {rate.selected.buy
+                                      ? rate.selected.buy + " zł"
+                                      : "N/A"}
+                                  </td>
+                                  <td>
+                                    {rate.selected.sell
+                                      ? rate.selected.sell + " zł"
+                                      : "N/A"}
+                                  </td>
+                                </tr>
+                              )}
+                            </React.Fragment>
+                          ))}
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+}
+export default ExchangeRates;

--- a/assets/js/components/Home.js
+++ b/assets/js/components/Home.js
@@ -1,32 +1,53 @@
 // ./assets/js/components/Home.js
 
 import React, {Component} from 'react';
-import {Route, Redirect, Switch, Link} from 'react-router-dom';
+import {Route, Redirect, Switch, Link, withRouter } from 'react-router-dom';
 import SetupCheck from "./SetupCheck";
+import ExchangeRates from "./ExchangeRates";
+import PageNotFound from "./PageNotFound";
 
 class Home extends Component {
+
+    componentDidMount() {
+        document.title = "Home - Telemedi Zadanko";
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.location !== prevProps.location) {
+            const titles = {
+                '/': 'Home - Telemedi Zadanko',
+                '/setup-check': 'Setup Check - Telemedi Zadanko',
+                '/exchange-rates': 'Exchange rates - Telemedi Zadanko',
+            };
+            document.title = titles[this.props.location.pathname] || '404 - not found';
+        }
+    }
 
     render() {
         return (
             <div>
                 <nav className="navbar navbar-expand-lg navbar-dark bg-dark">
-                    <Link className={"navbar-brand"} to={"#"}> Telemedi Zadanko </Link>
+                    <Link className={"navbar-brand"} to="/"> Telemedi Zadanko </Link>
                     <div id="navbarText">
                         <ul className="navbar-nav mr-auto">
                             <li className="nav-item">
                                 <Link className={"nav-link"} to={"/setup-check"}> React Setup Check </Link>
                             </li>
-
+                            <li className="nav-item">
+                                <Link className={"nav-link"} to={"/exchange-rates"}> Exchange rates </Link>
+                            </li>
                         </ul>
                     </div>
                 </nav>
                 <Switch>
-                    <Redirect exact from="/" to="/setup-check" />
+                    <Redirect exact from="/" to="/exchange-rates" />
                     <Route path="/setup-check" component={SetupCheck} />
+                    <Route path="/exchange-rates" component={ExchangeRates} />
+                    <Route component={PageNotFound} />
                 </Switch>
             </div>
         )
     }
 }
 
-export default Home;
+export default withRouter(Home);

--- a/assets/js/components/PageNotFound.js
+++ b/assets/js/components/PageNotFound.js
@@ -1,0 +1,21 @@
+// ./assets/js/components/Users.js
+
+import React, {Component} from 'react';
+
+const PageNotFound = () => {
+    return (
+        <div>
+            <section className="row-section">
+                <div className="container">
+                    <div className="row mt-5">
+                        <div className="col-md-8 offset-md-2">
+                            <h2 className="text-center mb-4">404 - page not found</h2>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    );
+};
+
+export default PageNotFound;

--- a/assets/js/components/SetupCheck.js
+++ b/assets/js/components/SetupCheck.js
@@ -2,6 +2,8 @@
 
 import React, {Component} from 'react';
 import axios from 'axios';
+import { getBaseUrl } from '../config/config';
+
 
 class SetupCheck extends Component {
     constructor() {
@@ -9,17 +11,12 @@ class SetupCheck extends Component {
         this.state = { setupCheck: {}, loading: true};
     }
 
-    getBaseUrl() {
-        return 'http://telemedi-zadanie.localhost';
-    }
-
     componentDidMount() {
         this.checkApiSetup();
     }
 
     checkApiSetup() {
-        //const baseUrl = this.getBaseUrl();
-        const baseUrl = 'http://telemedi-zadanie.localhost';
+        const baseUrl = getBaseUrl();
         axios.get(baseUrl + `/api/setup-check?testParam=1`).then(response => {
             let responseIsOK = response.data && response.data.testParam === 1
             this.setState({ setupCheck: responseIsOK, loading: false})
@@ -31,7 +28,7 @@ class SetupCheck extends Component {
 
     render() {
         const loading = this.state.loading;
-        return(
+        return( 
             <div>
                 <section className="row-section">
                     <div className="container">

--- a/assets/js/config/config.js
+++ b/assets/js/config/config.js
@@ -1,0 +1,3 @@
+export const getBaseUrl = () => {
+    return 'http://telemedi-zadanie.localhost';
+};

--- a/assets/js/utils/dateUtils.js
+++ b/assets/js/utils/dateUtils.js
@@ -1,0 +1,11 @@
+export function getFormattedDate() {
+    const today = new Date();
+    const year = today.getFullYear();
+    let mm = today.getMonth() + 1; // Miesiące zaczynają się od 0, więc dodajemy 1
+    let dd = today.getDate();
+
+    if (mm < 10) mm = "0" + mm;
+    if (dd < 10) dd = "0" + dd;
+
+    return `${year}-${mm}-${dd}`;
+}

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -8,6 +8,11 @@ setupcheck:
     path: /api/setup-check
     controller: App\Controller\DefaultController::setupCheck
 
+exchange_rates:
+    path: /api/exchange-rates
+    controller: App\Controller\ExchangeRatesController::getExchangeRates
+    methods: GET
+
 index:
     path: /{wildcard}
     defaults: {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
+    supported_currencies: ['EUR', 'USD', 'CZK', 'IDR', 'BRL']
 
 services:
     # default configuration for services in *this* file
@@ -18,6 +19,10 @@ services:
         exclude:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
+
+    App\Service\ExchangeRate\ExchangeRatesAPIService:
+        arguments:
+            $supportedCurrencies: '%supported_currencies%'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "task_telemedi",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/src/App/Controller/DefaultController.php
+++ b/src/App/Controller/DefaultController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 
 class DefaultController extends AbstractController
@@ -19,17 +20,15 @@ class DefaultController extends AbstractController
         );
     }
 
-    public function setupCheck(Request $request): Response
+    public function setupCheck(Request $request): JsonResponse
     {
-        $responseContent = json_encode([
+        $data = [
             'testParam' => $request->get('testParam')
                 ? (int) $request->get('testParam')
                 : null
-        ]);
-        return new Response(
-            $responseContent,
-            Response::HTTP_OK,
-            ['Content-type' => 'application/json']
+        ];
+        return new JsonResponse(
+            $data
         );
     }
 

--- a/src/App/Controller/ExchangeRatesController.php
+++ b/src/App/Controller/ExchangeRatesController.php
@@ -5,9 +5,62 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use App\Service\ExchangeRate\ExchangeRatesAPIService;
+use App\Service\ExchangeRate\ExchangeRatesService;
 
-class ExchangeRatesController extends AbstractController
-{
+class ExchangeRatesController extends AbstractController {
+    private $exchangeRatesApiService;
+    private $exchangeRatesService;
+
+    public function __construct(ExchangeRatesAPIService $exchangeRatesApiService,  ExchangeRatesService $exchangeRatesService) {
+        $this->exchangeRatesApiService = $exchangeRatesApiService;
+        $this->exchangeRatesService = $exchangeRatesService;
+    }
+
+    public function getExchangeRates(Request $request): JsonResponse {
+        $selectedDate = $request->query->get('date') ?? '';
+        if (date('Y-m-d') === $selectedDate) {
+            $selectedDate = '';
+        }
+        $selectedDateIntance = \DateTime::createFromFormat('Y-m-d', $selectedDate);
+        if ($selectedDate !== '' && (!$selectedDateIntance || ($selectedDateIntance && $selectedDateIntance->format('Y-m-d') !== $selectedDate))) {
+            return new JsonResponse(['error' => 'Invalid date format. Expected format: YYYY-mm-dd'], 400);
+        }
+
+        $now = new \DateTime('now', new \DateTimeZone('Europe/Warsaw'));
+        $noon = new \DateTime('today 12:00:00', new \DateTimeZone('Europe/Warsaw'));
+
+        $latestDate = ($now > $noon) ? date('Y-m-d') : date('Y-m-d', strtotime('-1 day'));
+        $ratesApiLatest = $this->exchangeRatesApiService->getExchangeRates($latestDate);
+        $ratesLatest = $this->exchangeRatesService->processExchangeRates($ratesApiLatest['rates']);
+
+        if ($selectedDate !== '') {
+            $ratesApiSelected = $this->exchangeRatesApiService->getExchangeRates($selectedDate);
+            $ratesSelected = $this->exchangeRatesService->processExchangeRates($ratesApiSelected['rates']);
+            foreach ($ratesLatest as $ind => $r) {
+                $ratesLatest[$ind]['selected'] = $this->getRateByCode($ratesSelected, $r['code']) ?? null;
+            }
+        }
+
+        $rslt = [
+            'rates' => $ratesLatest,
+            'latestDate' => $ratesApiLatest['effectiveDate'],
+            'isUpdatedToday' => ($now > $noon),
+            'selectedDate' => $selectedDate
+        ];
+        return new JsonResponse($rslt);
+    }
 
 
+    function getRateByCode($rates, $code) {
+        $result = array_filter($rates, function ($rate) use ($code) {
+            return $rate['code'] === $code;
+        });
+        if (empty($result)) {
+            return null;
+        }
+        return array_values($result)[0];
+    }
 }

--- a/src/App/Interfaces/ExchangeRate/RateStrategy.php
+++ b/src/App/Interfaces/ExchangeRate/RateStrategy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Interfaces\ExchangeRate;
+
+interface RateStrategy
+{
+    public function getBuyRate(float $mid): ?float;
+    public function getSellRate(float $mid): ?float;
+}

--- a/src/App/Service/ExchangeRate/ExchangeRate.php
+++ b/src/App/Service/ExchangeRate/ExchangeRate.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ExchangeRate;
+
+use App\Interfaces\ExchangeRate\RateStrategy;
+
+class ExchangeRate {
+    private $currency;
+    private $code;
+    private $mid;
+    private $rateStrategy;
+
+    public function __construct(string $currency, string $code, float $mid, RateStrategy $rateStrategy) {
+        $this->currency = $currency;
+        $this->code = $code;
+        $this->mid = $mid;
+        $this->rateStrategy = $rateStrategy;
+    }
+
+    public function getCurrency(): string {
+        return $this->currency;
+    }
+
+    public function getCode(): string {
+        return $this->code;
+    }
+
+    public function getMid(): float {
+        return $this->mid;
+    }
+
+    public function getBuyRate(): ?float {
+        return $this->rateStrategy->getBuyRate($this->mid);
+    }
+
+    public function getSellRate(): float {
+        return $this->rateStrategy->getSellRate($this->mid);
+    }
+}

--- a/src/App/Service/ExchangeRate/ExchangeRatesApiService.php
+++ b/src/App/Service/ExchangeRate/ExchangeRatesApiService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ExchangeRate;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+class ExchangeRatesApiService {
+    private $client;
+    private $cache;
+    private $supportedCurrencies;
+
+    public function __construct(HttpClientInterface $client, CacheInterface $cache, array $supportedCurrencies) {
+        $this->client = $client;
+        $this->cache = $cache;
+        $this->supportedCurrencies = $supportedCurrencies;
+    }
+
+    public function getExchangeRates(string $date): array {
+        $rslt = [
+            'effectiveDate' => '',
+            'rates' => []
+        ];
+        try {
+            return $this->cache->get('exchange_rates_data_' . $date, function (ItemInterface $item) use($date, $rslt) {
+                $item->expiresAfter(600); // 10 minutes
+                $response = $this->client->request('GET', 'https://api.nbp.pl/api/exchangerates/tables/A/'.$date.'/?format=json');
+                $apiData = $response->toArray();
+
+                if (is_array($apiData) && isset($apiData[0]['effectiveDate']) && isset($apiData[0]['rates']) && isset($apiData[0]['rates'][0])) {
+                    
+                    $rslt['effectiveDate'] = $apiData[0]['effectiveDate'];
+                    foreach($apiData[0]['rates'] as $rate) {
+                        if (in_array($rate['code'], $this->supportedCurrencies)) {
+                            $rslt['rates'][] = $rate;
+                        }
+                    }
+                }
+                return $rslt;
+            });
+        } catch (\Exception $e) { }
+        return $rslt;
+    }
+
+    public function getSupportedCurrencies(): array {
+        return $this->supportedCurrencies;
+    }
+}

--- a/src/App/Service/ExchangeRate/ExchangeRatesService.php
+++ b/src/App/Service/ExchangeRate/ExchangeRatesService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ExchangeRate;
+
+use App\Service\ExchangeRate\Strategy\EurUsdRateStrategy;
+use App\Service\ExchangeRate\Strategy\DefaultRateStrategy;
+use App\Interfaces\ExchangeRate\RateStrategy;
+
+class ExchangeRatesService {
+    private $strategies;
+
+    public function __construct() {
+        $this->strategies = [
+            'EUR' => new EurUsdRateStrategy(),
+            'USD' => new EurUsdRateStrategy(),
+        ];
+    }
+
+    public function getStrategy(string $code): RateStrategy {
+        return $this->strategies[$code] ?? new DefaultRateStrategy();
+    }
+
+    public function processExchangeRates(array $ratesData): array {
+        $processedRates = [];
+
+        foreach ($ratesData as $rate) {
+            $strategy = $this->getStrategy($rate['code']);
+            $exchangeRate = new ExchangeRate($rate['currency'], $rate['code'], round($rate['mid'], 8), $strategy);
+
+            $processedRates[] = [
+                'currency' => $exchangeRate->getCurrency(),
+                'code' => $exchangeRate->getCode(),
+                'mid' => $exchangeRate->getMid(),
+                'buy' => $exchangeRate->getBuyRate(),
+                'sell' => $exchangeRate->getSellRate()
+            ];
+        }
+
+        return $processedRates;
+    }
+}

--- a/src/App/Service/ExchangeRate/Strategy/DefaultRateStrategy.php
+++ b/src/App/Service/ExchangeRate/Strategy/DefaultRateStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ExchangeRate\Strategy;
+
+use App\Interfaces\ExchangeRate\RateStrategy;
+
+class DefaultRateStrategy implements RateStrategy {
+    public function getBuyRate(float $mid): ?float {
+        return null; // no buying rate
+    }
+
+    public function getSellRate(float $mid): ?float {
+        return round($mid + 0.15, 8);
+    }
+}

--- a/src/App/Service/ExchangeRate/Strategy/EurUsdRateStrategy.php
+++ b/src/App/Service/ExchangeRate/Strategy/EurUsdRateStrategy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\ExchangeRate\Strategy;
+
+use App\Interfaces\ExchangeRate\RateStrategy;
+
+class EurUsdRateStrategy implements RateStrategy {
+    public function getBuyRate(float $mid): ?float {
+        return round($mid - 0.05, 8);
+    }
+
+    public function getSellRate(float $mid): ?float {
+        return round($mid + 0.07, 8);
+    }
+}

--- a/tests/Integration/ExchangeRate/EchangeRateTest.php
+++ b/tests/Integration/ExchangeRate/EchangeRateTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Integration\ExchangeRate;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ExchangeRateTest extends WebTestCase
+{
+    public function testConnectivityWithValidDate(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/exchange-rates?date=2023-05-09');
+
+        $this->assertResponseIsSuccessful();
+        $response = $client->getResponse();
+        $this->assertJson($response->getContent());
+        $rates = json_decode($response->getContent(), TRUE);
+        
+        $this->assertIsArray($rates);
+        $this->assertArrayHasKey('rates', $rates);
+
+        $this->assertCount(5, $rates['rates']);
+        $this->assertEquals('USD', $rates['rates'][0]['code']);
+        $this->assertEquals(4.0117, $rates['rates'][0]['mid']);
+    }
+
+    public function testConnectivityWithWrongDate(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/api/exchange-rates?date=2023-01-aa');
+
+        $this->assertResponseStatusCodeSame(400);
+
+        $response = $client->getResponse();
+        $this->assertJson($response->getContent());
+
+        $expectedResponse = ['error' => 'Invalid date format. Expected format: YYYY-mm-dd'];
+        $responseData = json_decode($client->getResponse()->getContent(), true);
+        $this->assertSame($expectedResponse, $responseData);
+    }
+}

--- a/tests/Unit/ExchangeRate/ExchangeRatesApiServiceTest.php
+++ b/tests/Unit/ExchangeRate/ExchangeRatesApiServiceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Unit\ExchangeRate;
+
+use App\Service\ExchangeRate\ExchangeRatesApiService;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Component\Cache\CacheItem;
+
+class ExchangeRatesApiServiceTest extends WebTestCase
+{
+    public function testGetExchangeRates(): void
+    {
+        $mockResponse = new MockResponse(json_encode([[
+            'table' => 'A',
+            'no' => '001/A/NBP/2023',
+            'effectiveDate' => '2023-02-09',
+            'rates' => [
+                [
+                    'currency' => 'dolar amerykański',
+                    'code' => 'USD',
+                    'mid' => 4.0176
+                ],
+                [
+                    'currency' => 'euro',
+                    'code' => 'EUR',
+                    'mid' => 4.3344
+                ]
+            ]
+        ]]));
+
+        $mockHttpClient = new MockHttpClient($mockResponse);
+        
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->method('get')
+            ->willReturnCallback(function ($key, $callback) {
+                return $callback(new CacheItem());
+            });
+        
+        $supportedCurrencies = ['USD', 'EUR'];
+        $exchangeService = new ExchangeRatesApiService($mockHttpClient, $cache, $supportedCurrencies);
+
+        $rates = $exchangeService->getExchangeRates('2023-02-09');
+        $this->assertIsArray($rates);
+        $this->assertEquals('2023-02-09', $rates['effectiveDate']);
+        $this->assertCount(2, $rates['rates']);
+        $this->assertEquals('USD', $rates['rates'][0]['code']);
+        $this->assertEquals(4.0176, $rates['rates'][0]['mid']);
+    }
+
+
+}

--- a/tests/Unit/ExchangeRate/ExchangeRatesServiceTest.php
+++ b/tests/Unit/ExchangeRate/ExchangeRatesServiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Unit\ExchangeRate;
+
+use App\Service\ExchangeRate\ExchangeRatesService;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ExchangeRatesServiceTest extends WebTestCase {
+    public function testProcessExchangeRates(): void {
+        $ratesData = [
+            "effectiveDate" => "2024-01-01",
+            "rates" => [
+                ["currency" => "dolar amerykański", "code" => "USD", "mid" => 4.0176],
+                ["currency" => "euro", "code" => "EUR", "mid" => 4.3344],
+                ["currency" => "real (Brazylia)", "code" => "BRL", "mid" => 0.7047]
+            ]
+        ];
+
+        $exchangeService = new ExchangeRatesService();
+        $rates = $exchangeService->processExchangeRates($ratesData['rates']);
+
+        $this->assertIsArray($rates);
+        $this->assertCount(3, $rates);
+
+        $this->assertEquals('EUR', $rates[1]['code']);
+        $this->assertEquals(4.3344, $rates[1]['mid']);
+        $this->assertEquals(4.2844, $rates[1]['buy']);
+
+        $this->assertEquals('BRL', $rates[2]['code']);
+        $this->assertEquals(0.7047, $rates[2]['mid']);
+        $this->assertEquals(null, $rates[2]['buy']); 
+        $this->assertEquals(0.8547, $rates[2]['sell']);
+    }
+}

--- a/tsUnitExchangeRateExchangeRatesServiceTest.phpq
+++ b/tsUnitExchangeRateExchangeRatesServiceTest.phpq
@@ -1,0 +1,269 @@
+[1mdiff --git a/.gitignore b/.gitignore[m
+[1mindex 20c9e37..d2e147d 100644[m
+[1m--- a/.gitignore[m
+[1m+++ b/.gitignore[m
+[36m@@ -77,3 +77,5 @@[m [myarn-error.log[m
+ /phpunit.xml[m
+ .phpunit.result.cache[m
+ ###< phpunit/phpunit ###[m
+[32m+[m
+[32m+[m[32m.history[m
+\ No newline at end of file[m
+[1mdiff --git a/assets/css/app.css b/assets/css/app.css[m
+[1mindex cb33b13..abddd2f 100644[m
+[1m--- a/assets/css/app.css[m
+[1m+++ b/assets/css/app.css[m
+[36m@@ -1,3 +1,3 @@[m
+ body {[m
+[31m-    background-color: lightgray;[m
+[32m+[m[32m    background-color: #f2f2f2;[m
+ }[m
+[1mdiff --git a/assets/js/components/Home.js b/assets/js/components/Home.js[m
+[1mindex 4affbaa..65b8fe0 100644[m
+[1m--- a/assets/js/components/Home.js[m
+[1m+++ b/assets/js/components/Home.js[m
+[36m@@ -1,32 +1,53 @@[m
+ // ./assets/js/components/Home.js[m
+ [m
+ import React, {Component} from 'react';[m
+[31m-import {Route, Redirect, Switch, Link} from 'react-router-dom';[m
+[32m+[m[32mimport {Route, Redirect, Switch, Link, withRouter } from 'react-router-dom';[m
+ import SetupCheck from "./SetupCheck";[m
+[32m+[m[32mimport ExchangeRates from "./ExchangeRates";[m
+[32m+[m[32mimport PageNotFound from "./PageNotFound";[m
+ [m
+ class Home extends Component {[m
+ [m
+[32m+[m[32m    componentDidMount() {[m
+[32m+[m[32m        document.title = "Home - Telemedi Zadanko";[m
+[32m+[m[32m    }[m
+[32m+[m
+[32m+[m[32m    componentDidUpdate(prevProps) {[m
+[32m+[m[32m        if (this.props.location !== prevProps.location) {[m
+[32m+[m[32m            const titles = {[m
+[32m+[m[32m                '/': 'Home - Telemedi Zadanko',[m
+[32m+[m[32m                '/setup-check': 'Setup Check - Telemedi Zadanko',[m
+[32m+[m[32m                '/exchange-rates': 'Exchange rates - Telemedi Zadanko',[m
+[32m+[m[32m            };[m
+[32m+[m[32m            document.title = titles[this.props.location.pathname] || '404 - not found';[m
+[32m+[m[32m        }[m
+[32m+[m[32m    }[m
+[32m+[m
+     render() {[m
+         return ([m
+             <div>[m
+                 <nav className="navbar navbar-expand-lg navbar-dark bg-dark">[m
+[31m-                    <Link className={"navbar-brand"} to={"#"}> Telemedi Zadanko </Link>[m
+[32m+[m[32m                    <Link className={"navbar-brand"} to="/"> Telemedi Zadanko </Link>[m
+                     <div id="navbarText">[m
+                         <ul className="navbar-nav mr-auto">[m
+                             <li className="nav-item">[m
+                                 <Link className={"nav-link"} to={"/setup-check"}> React Setup Check </Link>[m
+                             </li>[m
+[31m-[m
+[32m+[m[32m                            <li className="nav-item">[m
+[32m+[m[32m                                <Link className={"nav-link"} to={"/exchange-rates"}> Exchange rates </Link>[m
+[32m+[m[32m                            </li>[m
+                         </ul>[m
+                     </div>[m
+                 </nav>[m
+                 <Switch>[m
+[31m-                    <Redirect exact from="/" to="/setup-check" />[m
+[32m+[m[32m                    <Redirect exact from="/" to="/exchange-rates" />[m
+                     <Route path="/setup-check" component={SetupCheck} />[m
+[32m+[m[32m                    <Route path="/exchange-rates" component={ExchangeRates} />[m
+[32m+[m[32m                    <Route component={PageNotFound} />[m
+                 </Switch>[m
+             </div>[m
+         )[m
+     }[m
+ }[m
+ [m
+[31m-export default Home;[m
+[32m+[m[32mexport default withRouter(Home);[m
+[1mdiff --git a/assets/js/components/SetupCheck.js b/assets/js/components/SetupCheck.js[m
+[1mindex 94c4df4..34576a4 100644[m
+[1m--- a/assets/js/components/SetupCheck.js[m
+[1m+++ b/assets/js/components/SetupCheck.js[m
+[36m@@ -2,6 +2,8 @@[m
+ [m
+ import React, {Component} from 'react';[m
+ import axios from 'axios';[m
+[32m+[m[32mimport { getBaseUrl } from '../config/config';[m
+[32m+[m
+ [m
+ class SetupCheck extends Component {[m
+     constructor() {[m
+[36m@@ -9,17 +11,12 @@[m [mclass SetupCheck extends Component {[m
+         this.state = { setupCheck: {}, loading: true};[m
+     }[m
+ [m
+[31m-    getBaseUrl() {[m
+[31m-        return 'http://telemedi-zadanie.localhost';[m
+[31m-    }[m
+[31m-[m
+     componentDidMount() {[m
+         this.checkApiSetup();[m
+     }[m
+ [m
+     checkApiSetup() {[m
+[31m-        //const baseUrl = this.getBaseUrl();[m
+[31m-        const baseUrl = 'http://telemedi-zadanie.localhost';[m
+[32m+[m[32m        const baseUrl = getBaseUrl();[m
+         axios.get(baseUrl + `/api/setup-check?testParam=1`).then(response => {[m
+             let responseIsOK = response.data && response.data.testParam === 1[m
+             this.setState({ setupCheck: responseIsOK, loading: false})[m
+[1mdiff --git a/config/routes.yaml b/config/routes.yaml[m
+[1mindex 38750d9..89a8fa6 100644[m
+[1m--- a/config/routes.yaml[m
+[1m+++ b/config/routes.yaml[m
+[36m@@ -8,6 +8,11 @@[m [msetupcheck:[m
+     path: /api/setup-check[m
+     controller: App\Controller\DefaultController::setupCheck[m
+ [m
+[32m+[m[32mexchange_rates:[m
+[32m+[m[32m    path: /api/exchange-rates[m
+[32m+[m[32m    controller: App\Controller\ExchangeRatesController::getExchangeRates[m
+[32m+[m[32m    methods: GET[m
+[32m+[m
+ index:[m
+     path: /{wildcard}[m
+     defaults: {[m
+[1mdiff --git a/config/services.yaml b/config/services.yaml[m
+[1mindex 469c440..af0376a 100644[m
+[1m--- a/config/services.yaml[m
+[1m+++ b/config/services.yaml[m
+[36m@@ -4,6 +4,7 @@[m
+ # Put parameters here that don't need to change on each machine where the app is deployed[m
+ # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration[m
+ parameters:[m
+[32m+[m[32m    supported_currencies: ['EUR', 'USD', 'CZK', 'IDR', 'BRL'][m
+ [m
+ services:[m
+     # default configuration for services in *this* file[m
+[36m@@ -19,6 +20,10 @@[m [mservices:[m
+             - '../src/DependencyInjection/'[m
+             - '../src/Entity/'[m
+ [m
+[32m+[m[32m    App\Service\ExchangeRate\ExchangeRatesAPIService:[m
+[32m+[m[32m        arguments:[m
+[32m+[m[32m            $supportedCurrencies: '%supported_currencies%'[m
+[32m+[m
+     # controllers are imported separately to make sure services can be injected[m
+     # as action arguments even if you don't extend any base controller class[m
+     App\Controller\:[m
+[1mdiff --git a/package-lock.json b/package-lock.json[m
+[1mindex e67b2b8..0e1d0ce 100644[m
+[1m--- a/package-lock.json[m
+[1m+++ b/package-lock.json[m
+[36m@@ -1,5 +1,5 @@[m
+ {[m
+[31m-    "name": "task_telemedi",[m
+[32m+[m[32m    "name": "html",[m
+     "lockfileVersion": 3,[m
+     "requires": true,[m
+     "packages": {[m
+[1mdiff --git a/src/App/Controller/DefaultController.php b/src/App/Controller/DefaultController.php[m
+[1mindex a4e434d..70b066f 100644[m
+[1m--- a/src/App/Controller/DefaultController.php[m
+[1m+++ b/src/App/Controller/DefaultController.php[m
+[36m@@ -7,6 +7,7 @@[m [mnamespace App\Controller;[m
+ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;[m
+ use Symfony\Component\HttpFoundation\Request;[m
+ use Symfony\Component\HttpFoundation\Response;[m
+[32m+[m[32muse Symfony\Component\HttpFoundation\JsonResponse;[m
+ [m
+ [m
+ class DefaultController extends AbstractController[m
+[36m@@ -19,17 +20,15 @@[m [mclass DefaultController extends AbstractController[m
+         );[m
+     }[m
+ [m
+[31m-    public function setupCheck(Request $request): Response[m
+[32m+[m[32m    public function setupCheck(Request $request): JsonResponse[m
+     {[m
+[31m-        $responseContent = json_encode([[m
+[32m+[m[32m        $data = [[m
+             'testParam' => $request->get('testParam')[m
+                 ? (int) $request->get('testParam')[m
+                 : null[m
+[31m-        ]);[m
+[31m-        return new Response([m
+[31m-            $responseContent,[m
+[31m-            Response::HTTP_OK,[m
+[31m-            ['Content-type' => 'application/json'][m
+[32m+[m[32m        ];[m
+[32m+[m[32m        return new JsonResponse([m
+[32m+[m[32m            $data[m
+         );[m
+     }[m
+ [m
+[1mdiff --git a/src/App/Controller/ExchangeRatesController.php b/src/App/Controller/ExchangeRatesController.php[m
+[1mindex 4853c99..e68a611 100644[m
+[1m--- a/src/App/Controller/ExchangeRatesController.php[m
+[1m+++ b/src/App/Controller/ExchangeRatesController.php[m
+[36m@@ -5,9 +5,62 @@[m [mdeclare(strict_types=1);[m
+ namespace App\Controller;[m
+ [m
+ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;[m
+[32m+[m[32muse Symfony\Component\HttpFoundation\Request;[m
+[32m+[m[32muse Symfony\Component\HttpFoundation\JsonResponse;[m
+[32m+[m[32muse App\Service\ExchangeRate\ExchangeRatesAPIService;[m
+[32m+[m[32muse App\Service\ExchangeRate\ExchangeRatesService;[m
+ [m
+[31m-class ExchangeRatesController extends AbstractController[m
+[31m-{[m
+[32m+[m[32mclass ExchangeRatesController extends AbstractController {[m
+[32m+[m[32m    private $exchangeRatesApiService;[m
+[32m+[m[32m    private $exchangeRatesService;[m
+ [m
+[32m+[m[32m    public function __construct(ExchangeRatesAPIService $exchangeRatesApiService,  ExchangeRatesService $exchangeRatesService) {[m
+[32m+[m[32m        $this->exchangeRatesApiService = $exchangeRatesApiService;[m
+[32m+[m[32m        $this->exchangeRatesService = $exchangeRatesService;[m
+[32m+[m[32m    }[m
+ [m
+[32m+[m[32m    public function getExchangeRates(Request $request): JsonResponse {[m
+[32m+[m[32m        $selectedDate = $request->query->get('date') ?? '';[m
+[32m+[m[32m        if (date('Y-m-d') === $selectedDate) {[m
+[32m+[m[32m            $selectedDate = '';[m
+[32m+[m[32m        }[m
+[32m+[m[32m        $selectedDateIntance = \DateTime::createFromFormat('Y-m-d', $selectedDate);[m
+[32m+[m[32m        if ($selectedDate !== '' && (!$selectedDateIntance || ($selectedDateIntance && $selectedDateIntance->format('Y-m-d') !== $selectedDate))) {[m
+[32m+[m[32m            return new JsonResponse(['error' => 'Invalid date format. Expected format: YYYY-mm-dd'], 400);[m
+[32m+[m[32m        }[m
+[32m+[m
+[32m+[m[32m        $now = new \DateTime('now', new \DateTimeZone('Europe/Warsaw'));[m
+[32m+[m[32m        $noon = new \DateTime('today 12:00:00', new \DateTimeZone('Europe/Warsaw'));[m
+[32m+[m
+[32m+[m[32m        $latestDate = ($now > $noon) ? date('Y-m-d') : date('Y-m-d', strtotime('-1 day'));[m
+[32m+[m[32m        $ratesApiLatest = $this->exchangeRatesApiService->getExchangeRates($latestDate);[m
+[32m+[m[32m        $ratesLatest = $this->exchangeRatesService->processExchangeRates($ratesApiLatest['rates']);[m
+[32m+[m
+[32m+[m[32m        if ($selectedDate !== '') {[m
+[32m+[m[32m            $ratesApiSelected = $this->exchangeRatesApiService->getExchangeRates($selectedDate);[m
+[32m+[m[32m            $ratesSelected = $this->exchangeRatesService->processExchangeRates($ratesApiSelected['rates']);[m
+[32m+[m[32m            foreach ($ratesLatest as $ind => $r) {[m
+[32m+[m[32m                $ratesLatest[$ind]['selected'] = $this->getRateByCode($ratesSelected, $r['code']) ?? null;[m
+[32m+[m[32m            }[m
+[32m+[m[32m        }[m
+[32m+[m
+[32m+[m[32m        $rslt = [[m
+[32m+[m[32m            'rates' => $ratesLatest,[m
+[32m+[m[32m            'latestDate' => $ratesApiLatest['effectiveDate'],[m
+[32m+[m[32m            'isUpdatedToday' => ($now > $noon),[m
+[32m+[m[32m            'selectedDate' => $selectedDate[m
+[32m+[m[32m        ];[m
+[32m+[m[32m        return new JsonResponse($rslt);[m
+[32m+[m[32m    }[m
+[32m+[m
+[32m+[m
+[32m+[m[32m    function getRateByCode($rates, $code) {[m
+[32m+[m[32m        $result = array_filter($rates, function ($rate) use ($code) {[m
+[32m+[m[32m            return $rate['code'] === $code;[m
+[32m+[m[32m        });[m
+[32m+[m[32m        if (empty($result)) {[m
+[32m+[m[32m            return null;[m
+[32m+[m[32m        }[m
+[32m+[m[32m        return array_values($result)[0];[m
+[32m+[m[32m    }[m
+ }[m


### PR DESCRIPTION
**Wymagania:**
	1. Zrobione. Dodałem osobny route. /exchange-rates
	2. Zrobione. Ustaliłem waluty. 
	2a. Zrobione. Zmiana walut w services.yaml, potem wstrzykiwane do App\Service\ExchangeRatesService. 
	3. Stosuje wzorzec strategii, do liczenie wartości kupna, sprzedaży dla róznych walut kursu średniego
	3a. Zrobione. Jak nie ma waluty wypisuje N/A
	3b. Zrobione. Jak nie ma waluty wypisuje N/A
	4. Zrobione. Wybrana dzisiejsza data w date picker
	4a. Zrobione. Od strony frontendu. Dopuszczamy daty od początku 2023 roku. Wykorzystuje natywną kontrolkę i argument min, dla starych przeglądarek, trzeba byłoby dopisać dodatkową logikę JS.
	4b. Zrobione. Sparametryzowanie linku po zmianie daty
	5abc. Zrobione. Dane w tabelce.

**Czas zadania ~ 7h**

```
PRZYGOTOWANIE

Zrobiłem fork
Docker
	docker compose
		(intalacja Php 7.2 - apache)
	Spojrzałem sobie na dockerfile
	Spojrzenie na docker-compose
	Na windows miałem problem z uruchmieniem w docker (brak katalogu vendor), nie zainstalowały się paczki composer i npm, zrobiłem to ręcznie z poziomu docker-compose
		composer install
		npm install
		docker exec -it recruitment-webserver npm run build
		zadziałały te działania
Przegląd projektu
	Sprawdziłem strukturę katalogów w projekcie i uzyte rozwiązania
		Webpack Encore, katalog assets na kod react, szablony twig
	Sprawdziłem paczki w composer.json jakie ma moduły system, do czego jest dostęp
	Sprawdziłem paczki w package.json, co mamy po stronie frontu
Rozpisanie wymogów
	podział na pliki do bieżącego projektu, rozpisanie szkieletu
	po stronie frontu mamy axios do łączenia backend NBP
	wygląda na to że to rozwiązanie powinno działać bez bazy danych
		nie widzę np klas ORM Doctrine
		baza by się przydała, aby zapisywać w niej przeliczniki okresowo, by nie pytać wciąż o to API NBP
		ew. można byłoby skorzystać z redis'aby
		systematyczne odświeżenie, mógłby się zająć mechanizm crone
		możnabyłoby zdecydować się na prosty zapis JSON do pliku
		JSON przykład:
		{"date_updated":"2024-11-06", "exchange_rates": {"usdpln":23.4, ...}}
		aby zaś nie komplikować zadania i przeznaczać czas na zadanie testowe skorzystałbym chociaz z mechanizmu cache (do systemu plików) dla GET na 10 min przechowania danych
		
FRONTEND 
Do wyświetlania tabeli wykorzystam istniejącego w projekcie bootstrap.
Zauważyłem, że zastosowany jest mechanizm catch-all w routingu, gdzie kierowane jest na ten sam szablon twig reacta z <div id="root"></div>
	dodam więc po prostu kolejną ścieżkę w Home.js dla nowego komponentu (url: /exchange-rates) react ExchangeRates, który zajmie się wysyłaniem request do backendu.
Przeniose też stałe dane dla react jak baseUrl do pliku config/config.js, aby nie powtarzać tej części kodu (DRY)
Chcąc zmieniać tytuł strony poprzez this.props.location opakowałem Home w withRouter
Dodałem ten route: 404 kiedy wpiszę się adres nieistniejący
Zmieniłem tez aby kliknięcie w logo kierowało na adres url '/'.

Komponent ExchangeRates
	W nim robię zapytanie GET przez axios, by móc pobrać dane walut z określonego dnia, wybranego przez intput type="date".
		endpoint
		GET /api/exchange-rates?date=2024-11-07
	Dane wyświetle w tabelce, z dodaniem spinnera podczas zapytania ze stylowaniem css przez bootstrap.
	Obsłużyłem też przypadki, kiedy pobranie danych się nie powiedzią (problem z serwerem appki czy API NBP)
	
	
BACKEND
Dodanie nowego endpoint dla API do routes.yaml (path: /api/exchange-rates) dla App\Controller\ExchangeRatesController::getExchangeRates
Zamieniam odpowiedź z Response na JsonResponse, od razu zwraca ['Content-type' => 'application/json']

Tworze pliki i daje je pod \src\App aby były załadowane przez autoload psr-4
	
Do łączenia z API używam interfejs HttpClientInterface w src\App\Service\ExchangeRate\ExchangeRatesApiService.php

W ExchangeRatesApiService w metodzie getExchangeRates zwracam z API NBP potrzebne dane. Stosuje też cache na 10min, aby przechować na jakiś czas dane by zapytanie cały czas nie było wysyłane do API. Zwracam też tylko te dane, które są wspierane w supported_currencies z pliku services.yaml, są wstrzykiwane przez DI do konstruktora. Mam też ochronę w try catch, jakby w API był jakiś błąd, sprawdzam czy otrzymuje schemat właściwych danych z NBP.
Stosuje też wzorzec strategii, aby też wyznaczyć Kursy kupna i sprzedaży dla różnych typów walut. W ten sposób eliminuje też korzystanie z IF, i tworze logikę do zachowań dla różnych typów walut.
	src\App\Interfaces\ExchangeRate\RateStrategy.php - intefejs do wzorca strategii
	src\App\Service\ExchangeRate\
		Strategy
			DefaultRateStrategy.php
			EurUsdRateStrategy.php
		ExchangeRate.php
		ExchangeRatesService.php
		ExchangeRatesApiService.php

W ExchangeRatesController.php sprawdzam też date wraz z ustawieniem timezone, dlatego bo dane dla dzisiejzego dnia są odświeżane przez NBP w ich API o godzinie 12. Jak jeszcze nie jest, to pobieram z poprzedniego dnia i też zaznaczam flagą isToday, co potem pójdzie do frontentu.
Waliduje też datę wysłaną przez użytkownika (Y-m-d) czy jest poprawna, i próbuje pobrać z jej pomocą dane przeliczników waluty, jeśli znajduje się w API NBP.
Date waliduje za pomocą \DateTime::createFromFormat('Y-m-d', $date);  bo jest to jedno pole, i chce sprawdzic dokładny format YYYY-mm-dd
Sprawdzam też czy zgadzają się waluty, dla przypadku że jakaś waluta nie była jeszcze dostępna dla zbyt wczesnej daty


TESTY
	Dodałem testy parę najważniejszych integracyjnych i jednostkowych.
	JEDNOSTKOWE
	tests\Unit\ExchangeRate\ExchangeRatesApiServiceTest.php
		Tam mockuje połączenie z API NBP oraz cache, sprawdzam czy funkcja dobrze zwraca dane
	tests\Unit\ExchangeRate\ExchangeRatesServiceTest.php
		sprawdzam czy dane dobrze się wpisują pod wzorzec strategii do pobieranie sell i buy rate
	
	INTEGRACYJNE
	tests\Integration\ExchangeRate\EchangeRateTest.php
		Sprawdzam połączenie na endpoint  /api/exchange-rates z roznymi parametrami na datę
		Sprawdzam właściwą datę, oraz źle wpisaną. Testuje czy zwraca właściwego JSON z API NBP lub czy zwraca status 400 i komunikat błędu, kiedy pobranie się nie powiodło.
		

```

![telemedi-zadanie-1](https://github.com/user-attachments/assets/f87475b6-b501-47c2-8880-50583976bea0)
![telemedi-zadanie-2](https://github.com/user-attachments/assets/09fc7ecb-e808-47b3-a2bc-792d5ee7a4ad)
![telemedi-zadanie-3-spinner](https://github.com/user-attachments/assets/002b3845-0840-4aa7-a730-1f68d05f73a5)

